### PR TITLE
Added EA App as PlatformClient, refactored BF1.go file

### DIFF
--- a/internal/domain/platform_client.go
+++ b/internal/domain/platform_client.go
@@ -9,6 +9,7 @@ type Platform string
 
 const (
 	PlatformOrigin Platform = "Origin"
+	PlatformEaApp  Platform = "EA App"
 )
 
 type PlatformClient struct {

--- a/internal/platforms/eaapp.go
+++ b/internal/platforms/eaapp.go
@@ -1,0 +1,20 @@
+package platforms
+
+import (
+	"github.com/cetteup/joinme.click-launcher/internal/domain"
+	"github.com/cetteup/joinme.click-launcher/pkg/game_launcher"
+	"github.com/cetteup/joinme.click-launcher/pkg/software_finder"
+)
+
+var EaClient = domain.PlatformClient{
+	Platform: domain.PlatformEaApp,
+	FinderConfig: software_finder.Config{
+		ForType:           software_finder.RegistryFinder,
+		RegistryKey:       software_finder.RegistryKeyLocalMachine,
+		RegistryPath:      "SOFTWARE\\WOW6432Node\\Electronic Arts\\EA Desktop",
+		RegistryValueName: "ClientPath",
+	},
+	LauncherConfig: game_launcher.Config{
+		ExecutableName: "EALauncher.exe",
+	},
+}

--- a/internal/titles/bf1.go
+++ b/internal/titles/bf1.go
@@ -15,7 +15,7 @@ const (
 var Bf1 = domain.GameTitle{
 	Name:           "Battlefield 1",
 	ProtocolScheme: "bf1",
-	PlatformClient: &platforms.OriginClient,
+	PlatformClient: &platforms.EaClient,
 	FinderConfigs: []software_finder.Config{
 		{
 			ForType:           software_finder.RegistryFinder,


### PR DESCRIPTION
Hey there,

I have made some changes to the BF1 file and PlatformClient in order to launch the game using the new EA App. 

![image](https://user-images.githubusercontent.com/40523695/236589119-5f564830-3ef6-4d6b-8226-f85423f88440.png)

![image](https://user-images.githubusercontent.com/40523695/236589126-733d34d4-4446-44e0-83a1-3f15919f601b.png)

 The code now allow users to launch the game, however it gets stuck on the main menu, I don't know if the issue is with the EA App launcher itself or with the game.exe file.

#### Also check the issue #58
